### PR TITLE
Update get_browser() call to new requirement

### DIFF
--- a/calibre-readability.recipe
+++ b/calibre-readability.recipe
@@ -35,7 +35,7 @@ class Readitlater(BasicNewsRecipe):
                 '''
 
     def get_browser(self):
-        br = BasicNewsRecipe.get_browser()
+        br = BasicNewsRecipe.get_browser(self)
         if self.username is not None and self.password is not None:
             login_url = self.INDEX + u'/login'
             br.open(login_url)


### PR DESCRIPTION
API call is broken with Calibre update 0.9.16
As per http://www.mobileread.com/forums/showthread.php?t=204109

One line fix
